### PR TITLE
gzip implementation for NG and backend

### DIFF
--- a/SigOpsMetrics/SigOpsMetrics.API/.config/dotnet-tools.json
+++ b/SigOpsMetrics/SigOpsMetrics.API/.config/dotnet-tools.json
@@ -1,5 +1,0 @@
-{
-  "version": 1,
-  "isRoot": true,
-  "tools": {}
-}

--- a/SigOpsMetrics/SigOpsMetrics.API/Startup.cs
+++ b/SigOpsMetrics/SigOpsMetrics.API/Startup.cs
@@ -2,6 +2,7 @@ using System.IO;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -33,6 +34,10 @@ namespace SigOpsMetrics.API
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddResponseCompression(options =>
+            {
+                options.Providers.Add<GzipCompressionProvider>();
+            });
             services.AddCors(options =>
             {
                 options.AddPolicy("AnyOrigin", builder => { builder.AllowAnyOrigin().AllowAnyMethod(); });
@@ -77,6 +82,7 @@ namespace SigOpsMetrics.API
             {
                 app.UseDeveloperExceptionPage();
             }
+            app.UseResponseCompression();
 
             app.UseHttpsRedirection();
 

--- a/SigOpsMetrics/SigOpsMetrics.SPA/ClientApp/package.json
+++ b/SigOpsMetrics/SigOpsMetrics.SPA/ClientApp/package.json
@@ -8,7 +8,8 @@
     "build:ssr": "ng run SigOpsMetrics:server:dev",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "gzip": "gzipper c --verbose --output-file-format [filename].[ext] ./dist ./dist/gzip/"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
NG and API should have gzip encoding now. I'm not sure which end points should actually be working on the page but I assume if one is working encoded then they all are. Steps for building the NG site are now:

from client app folder:
1. ng build --prod
2. npm run gzip
3. upload files to site from dist/gzip folder